### PR TITLE
修复当请求的返回值body为空时，报错的问题

### DIFF
--- a/src/RestApiClient.php
+++ b/src/RestApiClient.php
@@ -78,14 +78,7 @@ class RestApiClient
 
         $context = array('headers' => $headers, 'body' => $body);
 
-        $result = $this->spec->unserialize($body);
-        if (empty($result)) {
-            $message = "[RestApiClient #{$requestId}] Resut unserialize error (url: {$url}).";
-            $this->logger && $this->logger->error($message, $context);
-            throw new ResponseException($message);
-        }
-
-        return $result;
+        return $this->spec->unserialize($body);
     }
 
     protected function makeRequestId()


### PR DESCRIPTION
某些业务逻辑下，请求的返回值确实可能是空的，报错就会影响正常业务。